### PR TITLE
Enable Clang build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-language: c
+language: cpp
 compiler:
-  - gcc
+    - gcc
+    - clang
 
 before_install:
     - git clone https://github.com/cpputest/cpputest ../cpputest


### PR DESCRIPTION
As said in title, this enables the automatic build and run of the test for both GCC and Clang.
